### PR TITLE
Added support for models that feature float weights

### DIFF
--- a/app/src/main/java/com/amitshekhar/tflite/Classifier.java
+++ b/app/src/main/java/com/amitshekhar/tflite/Classifier.java
@@ -23,15 +23,21 @@ public interface Classifier {
         private final String title;
 
         /**
+         * Whether or not the model features quantized or float weights.
+         */
+        private final boolean quant;
+
+        /**
          * A sortable score for how good the recognition is relative to others. Higher should be better.
          */
         private final Float confidence;
 
         public Recognition(
-                final String id, final String title, final Float confidence) {
+                final String id, final String title, final Float confidence, final boolean quant) {
             this.id = id;
             this.title = title;
             this.confidence = confidence;
+            this.quant = quant;
         }
 
         public String getId() {

--- a/app/src/main/java/com/amitshekhar/tflite/MainActivity.java
+++ b/app/src/main/java/com/amitshekhar/tflite/MainActivity.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Executors;
 public class MainActivity extends AppCompatActivity {
 
     private static final String MODEL_PATH = "mobilenet_quant_v1_224.tflite";
+    private static final boolean QUANT = true;
     private static final String LABEL_PATH = "labels.txt";
     private static final int INPUT_SIZE = 224;
 
@@ -127,7 +128,8 @@ public class MainActivity extends AppCompatActivity {
                             getAssets(),
                             MODEL_PATH,
                             LABEL_PATH,
-                            INPUT_SIZE);
+                            INPUT_SIZE,
+                            QUANT);
                     makeButtonVisible();
                 } catch (final Exception e) {
                     throw new RuntimeException("Error initializing TensorFlow!", e);


### PR DESCRIPTION
Updated main java classes to add support for models that use float weights instead of quantized weights. When a user wants to use a model with float weights, all they need to do is change the model name as well as set the boolean variable "QUANT" to false in MainActivity.java. I added a sample model to test against in the app's asset folder called "mobilenet_float_v1_224.tflite", which is just the float version of mobilenet V1. 